### PR TITLE
:sparkles: Image embeds work properly now

### DIFF
--- a/mcoding_bot/cogs/starboard.py
+++ b/mcoding_bot/cogs/starboard.py
@@ -34,7 +34,7 @@ async def _orig_message(msg_id: int) -> Message | None:
 def embed_message(
     msg: UserMessage, points: int, bot: Bot
 ) -> tuple[str, Embed]:
-    return f"⭐ **{points} |** <#{msg.channel_id}>", Embed(
+    embed = Embed(
         description=_obj_or_none(msg.content) or "*file only*",
         color=bot.theme,
     ).set_author(
@@ -46,6 +46,11 @@ def embed_message(
         f"[Go to Message](https://discord.com/channels/"
         f"{bot.config.mcoding_server}/{msg.channel_id}/{msg.id})"
     )
+    if _obj_or_none(msg.attachments):
+        embed.set_image(msg.attachments[0].url)
+        embed.description = embed.description or f"*{msg.attachments[0].filename}*"
+    
+    return f"⭐ **{points} |** <#{msg.channel_id}>", embed
 
 
 async def _refresh_message(bot: Bot, message: Message):


### PR DESCRIPTION
Image embeds work since there is now an added `embed.set_image` call using the url from the message originally sent.