### PR TITLE
:bug: fix stats formatting for numbers <1000

### DIFF
--- a/mcoding_bot/tasks/update_channels.py
+++ b/mcoding_bot/tasks/update_channels.py
@@ -52,7 +52,10 @@ async def get_stats(bot: Bot):
 def display_stats(stat):
     int_stat = stat
 
-    if int_stat < 10 ** 6:
+    if int_stat < 10 ** 3:
+        pretty_stat = int_stat
+        unit = ""
+    elif int_stat < 10 ** 6:
         pretty_stat = int_stat / 10 ** 3
         unit = "K"
     else:


### PR DESCRIPTION
changes the `display_stats` function to show the member count as `740` instead of `0.74K`